### PR TITLE
readthedocs: Switch the builder to dirhtml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  builder: dirhtml
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:


### PR DESCRIPTION
I will also set up redirects from the old to the new, as described at https://docs.readthedocs.io/en/stable/user-defined-redirects.html#changing-your-sphinx-builder-from-html-to-dirhtml